### PR TITLE
correct fastapi() to FastAPI()

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 from fastapi import *
 from fastapi.responses import FileResponse
-app=fastapi()
+app=FastAPI()
 
 # Static Pages (Never Modify Code in this Block)
 @app.get("/", include_in_schema=False)


### PR DESCRIPTION
**林耿弘**

在develop branch中，修改`app=fastapi()` 成 `app=FastAPI()`